### PR TITLE
Changed default led color in LEDconstants.java to blue from orange

### DIFF
--- a/src/main/java/frc/robot/led/LEDConstants.java
+++ b/src/main/java/frc/robot/led/LEDConstants.java
@@ -16,5 +16,5 @@ public class LEDConstants {
   public static final Color kLockSwerve = Color.green;
   public static final Color kSuccess = Color.green;
   public static final Color kError = Color.red;
-  public static final Color kDefault = Color.orange;
+  public static final Color kDefault = Color.blue;
 }


### PR DESCRIPTION
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ X] I have read the [Contributing](Contributing.md) document.

- [ Nah] If code changes were made then they have been tested.

## Summary
Changed led constants file. The default led variable from orange to blue. 
<!-- What is this pull request for? Does it fix any issues? Would the changed code in this PR conflict with any other code? -->
